### PR TITLE
Minor improvements to youtube helper

### DIFF
--- a/src/cmd_processor/commands/clip.ts
+++ b/src/cmd_processor/commands/clip.ts
@@ -92,7 +92,7 @@ async function getModalData(interaction: ButtonInteraction, videoData: yt.YTSear
 
 
 async function getSelection(interaction: ChatInputCommandInteraction, query: string): Promise<[yt.YTSearchResult, ButtonInteraction] | null> {
-  const searchData: yt.YTSearchResult [] = await yt.search(query, 5, YT_TOKEN);
+  const searchData: yt.YTSearchResult [] = await yt.search(query, 5, 'video', YT_TOKEN);
   if(searchData === null) {
     await interaction.editReply('Failed to query youtube');
     return null;
@@ -163,7 +163,8 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
     }
     selection = {
       id: url.searchParams.get('v') as string,
-      name: q
+      name: q,
+      type: 'video'
     }
     let row = new ActionRowBuilder<ButtonBuilder>().addComponents(
       new ButtonBuilder()

--- a/src/cmd_processor/commands/play-many.ts
+++ b/src/cmd_processor/commands/play-many.ts
@@ -89,7 +89,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
   // Voicebots use this rather than querying discord for it
   await redisClient?.setnx(`discord:channel:${channelId}:guild-id`, member.guild.id);
   await redisClient?.checkIfWatched(WATCHED_CHANNELS_KEY, FREE_CHANNELS_KEY, channelId);
-  let videos = (await yt.list(ids[0], YT_TOKEN)).map(vid => ({ youtubeVideoId: vid.id, youtubeVideoTitle: vid.name, interactionId: interaction.id }));
+  let videos = (await yt.list(ids[0], 'video', YT_TOKEN)).map(vid => ({ youtubeVideoId: vid.id, youtubeVideoTitle: vid.name, interactionId: interaction.id }));
   
   try {
     await addSong(channelId, videos);

--- a/src/cmd_processor/commands/play.ts
+++ b/src/cmd_processor/commands/play.ts
@@ -18,7 +18,7 @@ const DEBUG = process.env['DEBUG'] === "1" ? true : false
 async function getSelection(interaction: ChatInputCommandInteraction): Promise<Array<string | null>> {
   const q = interaction.options.getString('query');
   if(!q) return [null, null]
-  const searchData: yt.YTSearchResult [] = await yt.search(q, 5, YT_TOKEN);
+  const searchData: yt.YTSearchResult [] = await yt.search(q, 5, 'video', YT_TOKEN);
   if(searchData === null) {
     await interaction.editReply('Failed to query youtube');
     return [null, null];

--- a/src/helpers/youtube.ts
+++ b/src/helpers/youtube.ts
@@ -1,18 +1,24 @@
 import axios from 'axios';
 import ytdl from '@distube/ytdl-core';
-import fs, { ReadStream } from 'fs';
+import { ReadStream, appendFileSync, createReadStream } from 'fs';
 import { LogType, logConsole } from './logger';
+import { FileHandle, open } from 'fs/promises';
+import { Readable } from 'stream';
 
 const SEARCH_ENDPOINT = 'https://www.googleapis.com/youtube/v3/search';
-const LIST_ENDPOINT = 'https://www.googleapis.com/youtube/v3/videos';
+const VIDEO_ENDPOINT = 'https://www.googleapis.com/youtube/v3/videos';
+const PLAYLIST_ENDPOINT = 'https://www.googleapis.com/youtube/v3/playlistItems';
+const MAX_RESULTS = 250;
+const MAX_PER_PAGE = 50;    // Upper bound on results returned in a single youtube api requ
 
 export interface YTSearchResult {
-  name: string,
-  id: string
+  name: string;
+  id: string;
+  type: 'video' | 'playlist';
 }
 
 
-async function request(url: string, params: any): Promise<YTSearchResult[]> {
+async function request(url: string, params: any): Promise<any> {
   let res;
   try {
     res = await axios.get(url, {
@@ -21,69 +27,122 @@ async function request(url: string, params: any): Promise<YTSearchResult[]> {
     });
   } catch(err: any) {
     if(err.response) {
-      logConsole({ msg: err.response.data, type: LogType.Error });
+      logConsole({ msg: `${JSON.stringify(err.response.data)}`, type: LogType.Error });
       logConsole({ msg: err.response.status, type: LogType.Error });
-      logConsole({ msg: err.response.headers, type: LogType.Error });
     } else {
       logConsole({ msg: err, type: LogType.Error });
     }
-    return[];
+    return { data: { items: [] } };
   }
-  const vidData: Array<YTSearchResult> = [];
-  for(const item of res.data.items) {
-    vidData.push({
-      name: item.snippet.title,
-      id: item.id.videoId ? item.id.videoId : item.id,
-    })
-  }
-  return vidData;
+  return res.data;
 }
 
 
-export async function search(query: string, count: number, key: string): Promise<Array<YTSearchResult>> {
-  return await(request(SEARCH_ENDPOINT, {
-    q: query,
-    key: key,
-    type: 'video',
-    part: 'snippet',
-    maxResults: count
-  }));
-}
+export async function search(query: string, count: number, type: 'video' | 'playlist', key: string): Promise<YTSearchResult[]> {
+  const results: YTSearchResult[] = [];
+  count = count > MAX_RESULTS ? MAX_RESULTS : count;
+  let maxResults = count <= MAX_PER_PAGE ? count : MAX_PER_PAGE;
+  let numPages = Math.ceil(count / MAX_PER_PAGE);
 
-
-export async function list(ids: string[], key: string): Promise<Array<YTSearchResult>> {
-  let results: YTSearchResult[] = [];
-  while(ids.length > 0) {
-    let batch = await(request(LIST_ENDPOINT, {
-      id: ids.splice(0, 50).join(','),
-      key,
-      type: 'video',
-      part: 'snippet,id',
+  for(let i = 0; i < numPages; i++) {
+    let data = await(request(SEARCH_ENDPOINT, {
+      q: query,
+      key: key,
+      type: type,
+      part: 'snippet',
+      maxResults: maxResults,
     }));
-    results = results.concat(batch);
+
+    for(let item of data.items) {
+      results.push({
+        name: item.snippet.title,
+        id: item.id.kind === 'youtube#video' ? item.id.videoId : item.id.playlistId,
+        type: item.id.kind === 'youtube#video' ? 'video' : 'playlist'
+      })
+      
+      if(results.length >= count) {
+        return results;
+      }
+    }
   }
   return results;
 }
 
 
-export async function download(songId: string, path?: string): Promise<fs.ReadStream> {
+export async function list(ids: string[], type: 'video' | 'playlist', key: string): Promise<YTSearchResult[]> {
+  let results: YTSearchResult[] = [];
+  const maxIds = 50;
+  const endpoint = type === 'video' ? VIDEO_ENDPOINT : PLAYLIST_ENDPOINT;
+  
+  while(ids.length > 0) {
+    let data = await(request(endpoint , {
+      id: ids.splice(0, maxIds).join(','),
+      key,
+      type: type,
+      part: 'snippet',
+    }));
+
+    for(let item of data.items)  {
+      results.push({
+        name: item.snippet.title,
+        id: item.id,
+        type: type
+      })
+    }
+  }
+  return results;
+}
+
+
+export async function playlistToVideos(playlistId: string, key: string): Promise<YTSearchResult[]> {
+  let results: YTSearchResult[] = [];
+  let nextPage = true;
+  let data;
+
+  while(nextPage) {
+    data = await(request(PLAYLIST_ENDPOINT, {
+      playlistId: playlistId,
+      key: key,
+      part: 'snippet',
+      pageToken: data ? data.nextPageToken : undefined 
+    }));
+
+    for(let item of data.items) { 
+      results.push({ 
+        name: item.snippet.title,
+        id: item.snippet.resourceId.videoId,
+        type: 'video' 
+      }) 
+    }
+    nextPage = data.nextPageToken ? true : false;
+  }
+  return results;
+}
+
+
+export async function download(songId: string, path?: string): Promise<Readable> {
   let download = ytdl(songId, { filter: 'audioonly' });
   if(!path) return download as ReadStream;
+  let f: FileHandle;
+
+  try {
+    f = await open(path, 'w+');
+  } catch(err) {
+    logConsole({ msg: `Error opening ${path} - ${err}`, type: LogType.Error })
+  }
+  
   return new Promise((resolve, reject) => {
-    let buff: any[] | null = [];
+    if(!f) reject(null);
     download.on('data', (chunk) => {
-      if(buff) buff.push(chunk);
-    })
+      appendFileSync(path, chunk);
+    });
     download.once('end', () => {
-      if(buff) {
-        fs.writeFileSync(path, Buffer.concat(buff));
-      }
-      buff = null;
-      resolve(fs.createReadStream(path));
+      resolve(f.createReadStream({autoClose: true}));
     });
     download.on('error', (err) => {
       logConsole({ msg: `${err}`, type: LogType.Error });
+      f.close();
       reject(null);
-    })
+    });
   })
 }

--- a/src/voice_bot/VoiceBot.ts
+++ b/src/voice_bot/VoiceBot.ts
@@ -23,6 +23,7 @@ import { List } from '../helpers/list';
 import { ChannelEvent, ChannelEventType } from '../helpers/common';
 import { LogType, logConsole } from '../helpers/logger';
 import { EventEmitter, once } from 'events';
+import { Readable } from 'stream';
 
 const VOICE_VOLUME = 0.15;
 const CANCEL_WATCH_EVENT = 'stop';
@@ -30,7 +31,7 @@ const CANCEL_WATCH_EVENT = 'stop';
 
 interface AudioResources {
   player: AudioPlayer;
-  readStream?: fs.ReadStream;
+  readStream?: Readable;
   discordResource?: AudioResource;
 }
 
@@ -245,7 +246,7 @@ export class VoiceBot {
     logConsole({ msg: `Guild ${this.guildId} cleanup`, type: LogType.Debug });
     this.audioResources.player.removeAllListeners(AudioPlayerStatus.Idle);
     this.audioResources.player.stop();
-    if(this.audioResources.readStream) this.audioResources.readStream.close();
+    if(this.audioResources.readStream) this.audioResources.readStream.destroy();
     delete this.audioResources.readStream;
     delete this.audioResources.discordResource;
     


### PR DESCRIPTION
Changes
 - Make the request function more generic. Just return the response,
   don't try to format it to a YTSearchResult[]
 - Search/List now support playlists. YTSearchResult now includes type
   which is either video or playlist
 - Add function to convert playlist id to a list of videos
 - Download function writes the stream directly to a file rather than
   storing the entire file in a buffer before writing. Should decrease
   memory usage (especially on large videos)
 - Clip, play, and play-many have been updated to use the new
   search/list function parameters