### PR TITLE
Pause command

### DIFF
--- a/src/cmd_processor/commands/pause.ts
+++ b/src/cmd_processor/commands/pause.ts
@@ -19,6 +19,6 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
 
 const command = new SlashCommandBuilder()
   .setName(`${DEBUG ? 'dev-pause' : 'pause'}`)
-  .setDescription('Skip to the next track')
+  .setDescription('Pause the queue')
 
 module.exports = { data: command, execute };

--- a/src/cmd_processor/commands/pause.ts
+++ b/src/cmd_processor/commands/pause.ts
@@ -1,0 +1,24 @@
+import { ChatInputCommandInteraction, GuildMember, SlashCommandBuilder } from 'discord.js';
+import { redisClient } from '../../helpers/redis';
+import { ChannelEvent, CHANNEL_EVENT_KEY } from '../../helpers/common';
+
+const DEBUG = process.env['DEBUG'] === "1" ? true : false;
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.reply('Pausing queue');
+  const member = interaction.member as GuildMember;
+  if(!member.voice.channelId) {
+    interaction.editReply(`You need to be in a voice channel to run this command`);
+  }
+
+  await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({
+    type: 'pause',
+    channelId: member.voice.channelId,
+    interactionId: interaction.id
+  } as ChannelEvent));
+}
+
+const command = new SlashCommandBuilder()
+  .setName(`${DEBUG ? 'dev-pause' : 'pause'}`)
+  .setDescription('Skip to the next track')
+
+module.exports = { data: command, execute };

--- a/src/cmd_processor/commands/skip.ts
+++ b/src/cmd_processor/commands/skip.ts
@@ -1,6 +1,6 @@
 import { ChatInputCommandInteraction, GuildMember, SlashCommandBuilder } from 'discord.js';
 import { redisClient } from '../../helpers/redis';
-import { ChannelEvent, CHANNEL_EVENT_KEY, ChannelEventType } from '../../helpers/common';
+import { ChannelEvent, CHANNEL_EVENT_KEY } from '../../helpers/common';
 
 const DEBUG = process.env['DEBUG'] === "1" ? true : false;
 async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
@@ -11,7 +11,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
   }
 
   await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({
-    type: ChannelEventType.Skip,
+    type: 'skip',
     channelId: member.voice.channelId,
     interactionId: interaction.id
   } as ChannelEvent));

--- a/src/cmd_processor/commands/stop.ts
+++ b/src/cmd_processor/commands/stop.ts
@@ -1,6 +1,6 @@
 import { ChatInputCommandInteraction, GuildMember, SlashCommandBuilder } from 'discord.js';
 import { redisClient } from '../../helpers/redis';
-import { CHANNEL_EVENT_KEY, ChannelEvent, ChannelEventType } from '../../helpers/common';
+import { CHANNEL_EVENT_KEY, ChannelEvent } from '../../helpers/common';
 
 const DEBUG = process.env['DEBUG'] === "1" ? true : false
 
@@ -11,7 +11,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
     interaction.editReply(`You need to be in a voice channel to run this command`);
   }
   await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({
-    type: ChannelEventType.Stop,
+    type: 'stop',
     channelId: member.voice.channelId,
     interactionId: interaction.id
   } as ChannelEvent));

--- a/src/cmd_processor/commands/unpause.ts
+++ b/src/cmd_processor/commands/unpause.ts
@@ -1,0 +1,24 @@
+import { ChatInputCommandInteraction, GuildMember, SlashCommandBuilder } from 'discord.js';
+import { redisClient } from '../../helpers/redis';
+import { ChannelEvent, CHANNEL_EVENT_KEY } from '../../helpers/common';
+
+const DEBUG = process.env['DEBUG'] === "1" ? true : false;
+async function execute(interaction: ChatInputCommandInteraction): Promise<void> {
+  await interaction.reply('Unpausing queue');
+  const member = interaction.member as GuildMember;
+  if(!member.voice.channelId) {
+    interaction.editReply(`You need to be in a voice channel to run this command`);
+  }
+
+  await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({
+    type: 'unpause',
+    channelId: member.voice.channelId,
+    interactionId: interaction.id
+  } as ChannelEvent));
+}
+
+const command = new SlashCommandBuilder()
+  .setName(`${DEBUG ? 'dev-unpause' : 'unpause'}`)
+  .setDescription('Skip to the next track')
+
+module.exports = { data: command, execute };

--- a/src/cmd_processor/commands/unpause.ts
+++ b/src/cmd_processor/commands/unpause.ts
@@ -19,6 +19,6 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
 
 const command = new SlashCommandBuilder()
   .setName(`${DEBUG ? 'dev-unpause' : 'unpause'}`)
-  .setDescription('Skip to the next track')
+  .setDescription('Unpause the queue')
 
 module.exports = { data: command, execute };

--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -4,13 +4,9 @@ import { LogType, logConsole } from './logger';
 
 export class DiscordClient extends Client { commands: any };
 
-export enum ChannelEventType {
-  Stop = 1,
-  Skip
-} 
 
 export interface ChannelEvent {
-	type: ChannelEventType;
+	type: 'stop' | 'skip' | 'pause';
 	channelId: Snowflake;
   interactionId?: Snowflake;
 }

--- a/src/helpers/common.ts
+++ b/src/helpers/common.ts
@@ -6,7 +6,7 @@ export class DiscordClient extends Client { commands: any };
 
 
 export interface ChannelEvent {
-	type: 'stop' | 'skip' | 'pause';
+	type: 'stop' | 'skip' | 'pause' | 'unpause';
 	channelId: Snowflake;
   interactionId?: Snowflake;
 }

--- a/src/voice_bot/VoiceBot.ts
+++ b/src/voice_bot/VoiceBot.ts
@@ -20,7 +20,7 @@ import { getSong, addSong, PlaylistEntry } from '../helpers/playlist';
 import { dequeue } from '../helpers/message_queue';
 import { Mutex } from 'async-mutex';
 import { List } from '../helpers/list';
-import { ChannelEvent, ChannelEventType } from '../helpers/common';
+import { ChannelEvent } from '../helpers/common';
 import { LogType, logConsole } from '../helpers/logger';
 import { EventEmitter, once } from 'events';
 import { Readable } from 'stream';
@@ -196,7 +196,7 @@ export class VoiceBot {
     let entry = event as PlaylistEntry;
     if(!entry) {
       logConsole({ msg: `Nothing in the queue for ${this.channelId}. Cleaning up` });
-      this.eventList.lpush({ type: ChannelEventType.Stop, channelId: this.channelId });
+      this.eventList.lpush({ type: 'stop', channelId: this.channelId });
       return;
     }
     
@@ -266,11 +266,11 @@ export class VoiceBot {
       if(!event) continue;
       
       switch(event.type) {
-        case ChannelEventType.Stop:
+        case 'stop':
           this.readyForEvents = false;
           await this.stop();
           break;
-        case ChannelEventType.Skip:
+        case 'skip':
           await this.playNext(true);
           break;
       }

--- a/src/voice_bot/VoiceBot.ts
+++ b/src/voice_bot/VoiceBot.ts
@@ -240,6 +240,25 @@ export class VoiceBot {
     delete voicebotList[this.channelId];
   }
 
+  
+  async pause(unpause = false, interactionId?: Snowflake) {
+    let currentState = this.audioResources.player.state.status;
+    let status;
+    if(unpause && currentState == AudioPlayerStatus.Paused) {
+      status = this.audioResources.player.unpause();
+    } else if(!unpause && currentState == AudioPlayerStatus.Playing) {
+      status = this.audioResources.player.pause();
+    }
+    
+    if(!status) { 
+      let msg = `Error ${unpause ? 'unpausing' : 'pausing'} the queue`
+      logConsole({ msg: `Channel ${this.channelId} - ${msg}`, type: LogType.Error }) 
+    } else {
+      let msg = `Queue is ${unpause ? 'unpaused' : 'paused'}`
+      logConsole({ msg: `Channel ${this.channelId} - ${msg}`, type: LogType.Debug }) 
+    }
+  }
+
 
   // Helper function to clean up guild resources.
   cleanupAudio(): void {
@@ -272,6 +291,12 @@ export class VoiceBot {
           break;
         case 'skip':
           await this.playNext(true);
+          break;
+        case 'pause':
+          await this.pause(false, event.interactionId);
+          break;
+        case 'unpause':
+          await this.pause(true, event.interactionId);
           break;
       }
     }


### PR DESCRIPTION
Add a pause command and fix a list bug
 - Pause and unpause with slash commands move the audio player into and out of the paused state
 - There was a bug in list that would cause the bot to freeze and then disconnect without calling the cleanup function or sending any errors.