### PR TITLE
Immediately return if user is not in a voice channel

### DIFF
--- a/src/cmd_processor/commands/pause.ts
+++ b/src/cmd_processor/commands/pause.ts
@@ -8,6 +8,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
   const member = interaction.member as GuildMember;
   if(!member.voice.channelId) {
     interaction.editReply(`You need to be in a voice channel to run this command`);
+    return;
   }
 
   await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({

--- a/src/cmd_processor/commands/skip.ts
+++ b/src/cmd_processor/commands/skip.ts
@@ -8,6 +8,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
   const member = interaction.member as GuildMember;
   if(!member.voice.channelId) {
     interaction.editReply(`You need to be in a voice channel to run this command`);
+    return;
   }
 
   await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({

--- a/src/cmd_processor/commands/stop.ts
+++ b/src/cmd_processor/commands/stop.ts
@@ -9,7 +9,9 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
   await interaction.reply(`Clearing the queue`);
   if(!member.voice.channelId) {
     interaction.editReply(`You need to be in a voice channel to run this command`);
+    return;
   }
+  
   await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({
     type: 'stop',
     channelId: member.voice.channelId,

--- a/src/cmd_processor/commands/unpause.ts
+++ b/src/cmd_processor/commands/unpause.ts
@@ -8,6 +8,7 @@ async function execute(interaction: ChatInputCommandInteraction): Promise<void> 
   const member = interaction.member as GuildMember;
   if(!member.voice.channelId) {
     interaction.editReply(`You need to be in a voice channel to run this command`);
+    return;
   }
 
   await redisClient?.publish(CHANNEL_EVENT_KEY, JSON.stringify({


### PR DESCRIPTION
Pause, unpause, skip, and stop did not immediately return if the user is in a channel. This commit fixes that.